### PR TITLE
Copying encryption key Bugfix

### DIFF
--- a/UCryptPortal/src/app/modules/user/components/encryption/encryption.component.html
+++ b/UCryptPortal/src/app/modules/user/components/encryption/encryption.component.html
@@ -83,7 +83,7 @@
                         <!-- Copy & Save Buttons -->
                         <div class="enc-key-options">
                           <!-- Copy Button -->
-                          <button type="button" class="btn" pTooltip="Copy Text" tooltipPosition="top" (click)="copyKey()">
+                          <button type="button" class="btn" pTooltip="Copy Text" tooltipPosition="top" (click)="copyKey(true)">
                             <svg xmlns="http://www.w3.org/2000/svg" width="20.208" height="23.009" viewBox="0 0 20.208 23.009">
                               <path id="Icon_awesome-copy" data-name="Icon awesome-copy"
                                 d="M14.005,19.608v1.751a1.05,1.05,0,0,1-1.05,1.05H1.05A1.05,1.05,0,0,1,0,21.358V5.252A1.05,1.05,0,0,1,1.05,4.2H4.2V17.157a2.454,2.454,0,0,0,2.451,2.451Zm0-15.056V0H6.653A1.05,1.05,0,0,0,5.6,1.05V17.157a1.05,1.05,0,0,0,1.05,1.05h11.9a1.05,1.05,0,0,0,1.05-1.05V5.6H15.056A1.053,1.053,0,0,1,14.005,4.552ZM19.3,3.194,16.414.308A1.05,1.05,0,0,0,15.671,0h-.265V4.2h4.2V3.936a1.05,1.05,0,0,0-.308-.743Z"
@@ -309,7 +309,7 @@
               <textarea class="form-control no-resize fs-10 output" formControlName="encryptedText" id="" rows="4"></textarea>
               <!-- Copy Button -->
               <div class="enc-key-options">
-                <button type="button" class="btn" pTooltip="Copy Text" tooltipPosition="top">
+                <button type="button" class="btn" pTooltip="Copy Text" tooltipPosition="top" (click)="copyKey()">
                   <svg xmlns="http://www.w3.org/2000/svg" width="20.208" height="23.009" viewBox="0 0 20.208 23.009">
                     <path id="Icon_awesome-copy" data-name="Icon awesome-copy"
                       d="M14.005,19.608v1.751a1.05,1.05,0,0,1-1.05,1.05H1.05A1.05,1.05,0,0,1,0,21.358V5.252A1.05,1.05,0,0,1,1.05,4.2H4.2V17.157a2.454,2.454,0,0,0,2.451,2.451Zm0-15.056V0H6.653A1.05,1.05,0,0,0,5.6,1.05V17.157a1.05,1.05,0,0,0,1.05,1.05h11.9a1.05,1.05,0,0,0,1.05-1.05V5.6H15.056A1.053,1.053,0,0,1,14.005,4.552ZM19.3,3.194,16.414.308A1.05,1.05,0,0,0,15.671,0h-.265V4.2h4.2V3.936a1.05,1.05,0,0,0-.308-.743Z"

--- a/UCryptPortal/src/app/modules/user/components/encryption/encryption.component.html
+++ b/UCryptPortal/src/app/modules/user/components/encryption/encryption.component.html
@@ -83,7 +83,7 @@
                         <!-- Copy & Save Buttons -->
                         <div class="enc-key-options">
                           <!-- Copy Button -->
-                          <button type="button" class="btn" pTooltip="Copy Text" tooltipPosition="top">
+                          <button type="button" class="btn" pTooltip="Copy Text" tooltipPosition="top" (click)="copyKey()">
                             <svg xmlns="http://www.w3.org/2000/svg" width="20.208" height="23.009" viewBox="0 0 20.208 23.009">
                               <path id="Icon_awesome-copy" data-name="Icon awesome-copy"
                                 d="M14.005,19.608v1.751a1.05,1.05,0,0,1-1.05,1.05H1.05A1.05,1.05,0,0,1,0,21.358V5.252A1.05,1.05,0,0,1,1.05,4.2H4.2V17.157a2.454,2.454,0,0,0,2.451,2.451Zm0-15.056V0H6.653A1.05,1.05,0,0,0,5.6,1.05V17.157a1.05,1.05,0,0,0,1.05,1.05h11.9a1.05,1.05,0,0,0,1.05-1.05V5.6H15.056A1.053,1.053,0,0,1,14.005,4.552ZM19.3,3.194,16.414.308A1.05,1.05,0,0,0,15.671,0h-.265V4.2h4.2V3.936a1.05,1.05,0,0,0-.308-.743Z"
@@ -258,7 +258,7 @@
                   <!-- Copy & Save Buttons -->
                   <div class="enc-key-options">
                     <!-- Copy Button -->
-                    <button type="button" class="btn" pTooltip="Copy Text" tooltipPosition="top">
+                    <button type="button" class="btn" pTooltip="Copy Text" tooltipPosition="top" (click)="copyKey()">
                       <svg xmlns="http://www.w3.org/2000/svg" width="20.208" height="23.009" viewBox="0 0 20.208 23.009">
                         <path id="Icon_awesome-copy" data-name="Icon awesome-copy"
                           d="M14.005,19.608v1.751a1.05,1.05,0,0,1-1.05,1.05H1.05A1.05,1.05,0,0,1,0,21.358V5.252A1.05,1.05,0,0,1,1.05,4.2H4.2V17.157a2.454,2.454,0,0,0,2.451,2.451Zm0-15.056V0H6.653A1.05,1.05,0,0,0,5.6,1.05V17.157a1.05,1.05,0,0,0,1.05,1.05h11.9a1.05,1.05,0,0,0,1.05-1.05V5.6H15.056A1.053,1.053,0,0,1,14.005,4.552ZM19.3,3.194,16.414.308A1.05,1.05,0,0,0,15.671,0h-.265V4.2h4.2V3.936a1.05,1.05,0,0,0-.308-.743Z"

--- a/UCryptPortal/src/app/modules/user/components/encryption/encryption.component.ts
+++ b/UCryptPortal/src/app/modules/user/components/encryption/encryption.component.ts
@@ -118,6 +118,13 @@ export class EncryptionComponent {
     })
   }
 
+  copyKey(){
+    let keyValue = this.form.get('encryptionKey')?.value;
+    navigator.clipboard.writeText(keyValue)
+    .then(() => console.log('Text copied!'))
+    .catch(err => console.error('Failed to copy text:', err));
+  }
+
   saveKey(isFile?:boolean){
     if(isFile){
       if( this.fileForm.get('encryptionKey')?.invalid || this.fileForm.get('encryptionTechnique')?.invalid){

--- a/UCryptPortal/src/app/modules/user/components/encryption/encryption.component.ts
+++ b/UCryptPortal/src/app/modules/user/components/encryption/encryption.component.ts
@@ -118,8 +118,8 @@ export class EncryptionComponent {
     })
   }
 
-  copyKey(){
-    let keyValue = this.form.get('encryptionKey')?.value;
+  copyKey(isFile?: boolean){
+    let keyValue = (isFile)? this.fileForm.get('encryptionKey')?.value: this.form.get('encryptionKey')?.value;
     navigator.clipboard.writeText(keyValue)
     .then(() => console.log('Text copied!'))
     .catch(err => console.error('Failed to copy text:', err));


### PR DESCRIPTION
This PR addresses a bug where users are not able to copy the encryption key using the "_copy key_" button in the encryption page. Users are now able to copy their keys with the button. **This is a critical UX bug.** 